### PR TITLE
Fix kcreset full and add kcreset session

### DIFF
--- a/KillCounter/KillCounter.lua
+++ b/KillCounter/KillCounter.lua
@@ -676,6 +676,7 @@ function KC_G.OnCharacterLoad(eventCode, initialLoad)
             EVENT_MANAGER:RegisterForEvent(KC_G.name,
                                            EVENT_OBJECTIVE_CONTROL_STATE,
                                            SC_G.ObjectiveControlState)
+            KC_G.backupStats()
         end
     elseif KC_ON then
         KC_G.show()
@@ -828,6 +829,9 @@ function KC_G.OnInitialized(self)
             KC_G.statsResetFull()
             d("Stats Fully Reset")
             SC_G.ResetSeigeStats()
+        elseif extra == "session" then
+            KC_G.statsResetSession()
+            d("Session Stats Reset")
         else
             d("Current Stats Reset")
         end
@@ -1151,6 +1155,22 @@ function KC_G.doDeathStreakEnd()
     deathStreak = 0
 end
 
+function KC_G.backupStats()
+    local sDisplayName = GetDisplayName()
+    local sUnitName = GetUnitName("player")
+    KC_G.statsBackup = ZO_DeepTableCopy(_G["KillCounter_Data"]["Default"][sDisplayName][sUnitName])
+end
+
+function KC_G.statsResetSession()
+    local sDisplayName = GetDisplayName()
+    local sUnitName = GetUnitName("player")
+    ZO_ClearTable(KC_G.savedVars)
+    ZO_DeepTableCopy(KC_G.statsBackup, _G["KillCounter_Data"]["Default"][sDisplayName][sUnitName])
+    -- KC_G.loadKilled()
+    -- d("saved vars: " .. #KC_G.savedVars.Killed)
+    KC_G.updateStats(true)
+end
+
 -- function KC_statsResetFull()
 function KC_G.statsResetFull()
     local defaultValues = ZO_DeepTableCopy(defaults)
@@ -1166,6 +1186,7 @@ function KC_G.statsResetFull()
     KC_G.savedVars.longestDeathStreak = defaultValues.longestDeathStreak
     -- KC_G.loadKilled()
     -- d("saved vars: " .. #KC_G.savedVars.Killed)
+    KC_G.backupStats()
     KC_G.updateStats(true)
 end
 

--- a/KillCounter/KillCounter.lua
+++ b/KillCounter/KillCounter.lua
@@ -88,8 +88,9 @@ local defaults = {
 
 KC_G = {
     name = "KillCounter",
-    savedVars = {}
-    -- svDefaults = defaults
+    savedVars = {},
+    -- svDefaults = defaults,
+    SC = defaults.SC
 }
 
 function KC_G.GetCounter() return counter end

--- a/KillCounter/KillCounter.lua
+++ b/KillCounter/KillCounter.lua
@@ -91,7 +91,7 @@ KC_G = {
     savedVars = {},
     -- svDefaults = defaults,
     SC = defaults.SC,
-    
+    statsBackup = {},
 }
 
 function KC_G.GetCounter() return counter end

--- a/KillCounter/KillCounter.lua
+++ b/KillCounter/KillCounter.lua
@@ -90,7 +90,8 @@ KC_G = {
     name = "KillCounter",
     savedVars = {},
     -- svDefaults = defaults,
-    SC = defaults.SC
+    SC = defaults.SC,
+    
 }
 
 function KC_G.GetCounter() return counter end
@@ -1152,11 +1153,17 @@ end
 
 -- function KC_statsResetFull()
 function KC_G.statsResetFull()
-    KC_G.savedVars.players = {}
-    KC_G.savedVars.totalKills = 0
-    KC_G.savedVars.totalDeaths = 0
-    KC_G.savedVars.longestStreak = 0
-    KC_G.savedVars.longestDeathStreak = 0
+    local defaultValues = ZO_DeepTableCopy(defaults)
+    KC_G.savedVars.SC = defaultValues.SC
+    KC_G.savedVars.kbSpells = defaultValues.kbSpells
+    KC_G.savedVars.longestKBStreak = defaultValues.longestKBStreak
+    KC_G.savedVars.players = defaultValues.players
+    KC_G.savedVars.rankPointsGained = defaultValues.rankPointsGained
+    KC_G.savedVars.longestStreak = defaultValues.longestStreak
+    KC_G.savedVars.totalKills = defaultValues.totalKills
+    KC_G.savedVars.totalDeaths = defaultValues.totalDeaths
+    KC_G.savedVars.totalKillingBlows = defaultValues.totalKillingBlows
+    KC_G.savedVars.longestDeathStreak = defaultValues.longestDeathStreak
     -- KC_G.loadKilled()
     -- d("saved vars: " .. #KC_G.savedVars.Killed)
     KC_G.updateStats(true)

--- a/KillCounter/keepcounter.lua
+++ b/KillCounter/keepcounter.lua
@@ -354,7 +354,7 @@ end
 
 function SC_G.ResetSeigeStats()
     SC_G.resetStreaks()
-    KC_G.savedVars.SC = KC_Fn.table_shallow_copy(KC_G.svDefaults.SC)
+    KC_G.savedVars.SC = KC_G.SC
 end
 -- control stat fires before capture area status, but capstatus only happens when you are there.
 


### PR DESCRIPTION
This fixes an issue where the `/kcreset full` command would cause a UI error when it attempted to reset the keepcounter stats due to a missing table. It also fixes several omissions in `/kcreset full` that would cause stats to be carried over instead of being a true full reset.

This PR also adds a new option for `/kcreset`.
`/kcreset session` will reset the statistics (in, fact, reset the savedvariables completely) to the last state they were in when you loaded into an AvA world. This fills a niche in killcounter between just resetting the live visualization of the stats (the standard `/kcreset`), and doing a full reset.